### PR TITLE
Fix GWT compiling war build on Windows

### DIFF
--- a/che-plugin-ide-menu-archetype/src/main/resources/archetype-resources/assembly/assembly-ide-war/pom.xml
+++ b/che-plugin-ide-menu-archetype/src/main/resources/archetype-resources/assembly/assembly-ide-war/pom.xml
@@ -184,7 +184,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
                 <configuration>
-                    <packagingExcludes>%regex[WEB-INF\/lib\/(?!.*j2ee).*.jar]</packagingExcludes>
+                    <packagingExcludes>%regex[WEB-INF\\lib\\(?!.*j2ee).*.jar]</packagingExcludes>
                     <overlays>
                         <overlay>
                             <groupId>org.eclipse.che</groupId>

--- a/che-plugin-ide-wizard-archetype/src/main/resources/archetype-resources/assembly/assembly-ide-war/pom.xml
+++ b/che-plugin-ide-wizard-archetype/src/main/resources/archetype-resources/assembly/assembly-ide-war/pom.xml
@@ -188,7 +188,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
                 <configuration>
-                    <packagingExcludes>%regex[WEB-INF\/lib\/(?!.*j2ee).*.jar]</packagingExcludes>
+                    <packagingExcludes>%regex[WEB-INF\\lib\\(?!.*j2ee).*.jar]</packagingExcludes>
                     <overlays>
                         <overlay>
                             <groupId>org.eclipse.che</groupId>


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Fix GWT compiling war packaging by using correct regex that works on all OS.