### PR TITLE
CHE-3959: Create archetype to add new custom agent that is not language server

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ mvn archetype:generate                                \
   -DarchetypeVersion=1.0-SNAPSHOT                     \
   -DgroupId=<VALUE>                                   \
   -DartifactId=<VALUE>                                \
-  -Dche=<CHE-VERSION                                  \
+  -Dche=<CHE-VERSION>                                 \
   -Dversion=<VALUE>
 ```
 
@@ -46,6 +46,7 @@ mvn clean install
 #### Archetype List
 | archetypeArtifactId   | Descriptions                              |
 |-----------------------|-------------------------------------------|
+| `che-agent-archetype` |  left-aligned                     |
 | `che-plugin-ide-menu-archetype` |  left-aligned                     |
 | `archetype-plugin-wizard` |  left-aligned                     |
 

--- a/che-agent-archetype/pom.xml
+++ b/che-agent-archetype/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2012-2017 Codenvy, S.A.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Codenvy, S.A. - initial API and implementation
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>eclipse-che-archetype-parent</artifactId>
+        <groupId>org.eclipse.che.archetype</groupId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <groupId>org.eclipse.che.archetype</groupId>
+    <artifactId>che-agent-archetype</artifactId>
+    <packaging>maven-archetype</packaging>
+    <name>che-agent-archetype</name>
+    <description>Provides version of third parties artifacts to use in Codenvy platform projects</description>
+    <build>
+        <extensions>
+            <extension>
+                <groupId>org.apache.maven.wagon</groupId>
+                <artifactId>wagon-webdav-jackrabbit</artifactId>
+                <version>2.7</version>
+            </extension>
+            <extension>
+                <groupId>org.apache.maven.wagon</groupId>
+                <artifactId>wagon-file</artifactId>
+                <version>2.7</version>
+            </extension>
+            <extension>
+                <groupId>org.apache.maven.wagon</groupId>
+                <artifactId>wagon-http</artifactId>
+                <version>2.7</version>
+            </extension>
+            <extension>
+                <groupId>org.apache.maven.archetype</groupId>
+                <artifactId>archetype-packaging</artifactId>
+                <version>2.3</version>
+            </extension>
+        </extensions>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-archetype-plugin</artifactId>
+                    <version>2.3</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>**/assembly/pom.xml</exclude>
+                        <exclude>**/goal.txt</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/che-agent-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/che-agent-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2012-2017 Codenvy, S.A.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Codenvy, S.A. - initial API and implementation
+
+-->
+<archetype-descriptor
+        xsi:schemaLocation="http://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.0.0 http://maven.apache.org/xsd/archetype-descriptor-1.0.0.xsd"
+        name="agent-parent"
+        xmlns="http://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <requiredProperties>
+        <requiredProperty key="che"/>
+    </requiredProperties>
+    <modules>
+        <module id="agents" dir="agents" name="agents">
+            <modules>
+                <module id="__rootArtifactId__" dir="__rootArtifactId__" name="__rootArtifactId__">
+                    <fileSets>
+                        <fileSet filtered="true" encoding="UTF-8">
+                            <directory>src/main/java</directory>
+                            <includes>
+                                <include>**/*.java</include>
+                                <include>**/*.xml</include>
+                            </includes>
+                        </fileSet>
+                        <fileSet filtered="true" encoding="UTF-8">
+                            <directory>src/main/resources</directory>
+                            <includes>
+                                <include>**/*.json</include>
+                                <include>**/*.sh</include>
+                            </includes>
+                        </fileSet>
+                    </fileSets>
+                </module>
+            </modules>
+        </module>
+        <module id="che-assembly-parent" dir="assembly" name="che-assembly-parent">
+            <modules>
+                <module id="assembly-wsmaster-war" dir="assembly-wsmaster-war" name="assembly-wsmaster-war">
+                    <fileSets>
+                        <fileSet filtered="true" encoding="UTF-8">
+                            <directory>src/assembly</directory>
+                            <includes>
+                                <include>**/*.xml</include>
+                            </includes>
+                        </fileSet>
+                    </fileSets>
+                </module>
+                <module id="assembly-main" dir="assembly-main" name="assembly-main">
+                    <fileSets>
+                        <fileSet filtered="true" encoding="UTF-8">
+                            <directory>src/assembly</directory>
+                            <includes>
+                                <include>**/*.xml</include>
+                            </includes>
+                        </fileSet>
+                    </fileSets>
+                </module>
+            </modules>
+        </module>
+    </modules>
+</archetype-descriptor>

--- a/che-agent-archetype/src/main/resources/archetype-resources/agents/__rootArtifactId__/pom.xml
+++ b/che-agent-archetype/src/main/resources/archetype-resources/agents/__rootArtifactId__/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2012-2017 Codenvy, S.A.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Codenvy, S.A. - initial API and implementation
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>che-agents-parent</artifactId>
+        <groupId>${groupId}</groupId>
+        <version>${version}</version>
+    </parent>
+    <artifactId>sample-agent</artifactId>
+    <name>Che :: Agents :: Sample</name>
+    <properties>
+        <findbugs.failonerror>false</findbugs.failonerror>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.inject.extensions</groupId>
+            <artifactId>guice-multibindings</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-agent-shared</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-commons-inject</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/che-agent-archetype/src/main/resources/archetype-resources/agents/__rootArtifactId__/src/main/java/__packageInPathFormat__/agent/SampleAgent.java
+++ b/che-agent-archetype/src/main/resources/archetype-resources/agents/__rootArtifactId__/src/main/java/__packageInPathFormat__/agent/SampleAgent.java
@@ -1,0 +1,35 @@
+#set( $symbol_pound = '#' )
+#set( $symbol_dollar = '$' )
+#set( $symbol_escape = '\' )
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package ${package}.agent;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+import org.eclipse.che.api.agent.shared.model.impl.BasicAgent;
+
+import java.io.IOException;
+
+/**
+ * Sample agent.
+ */
+@Singleton
+public class SampleAgent extends BasicAgent {
+    private static final String AGENT_DESCRIPTOR = "${package}.sample.json";
+    private static final String AGENT_SCRIPT     = "${package}.sample.script.sh";
+
+    @Inject
+    public SampleAgent() throws IOException {
+        super(AGENT_DESCRIPTOR, AGENT_SCRIPT);
+    }
+}

--- a/che-agent-archetype/src/main/resources/archetype-resources/agents/__rootArtifactId__/src/main/java/__packageInPathFormat__/agent/SampleAgentModule.java
+++ b/che-agent-archetype/src/main/resources/archetype-resources/agents/__rootArtifactId__/src/main/java/__packageInPathFormat__/agent/SampleAgentModule.java
@@ -1,0 +1,31 @@
+#set( $symbol_pound = '#' )
+#set( $symbol_dollar = '$' )
+#set( $symbol_escape = '\' )
+/*******************************************************************************
+ * Copyright (c) 2012-2017 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package ${package}.agent;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.multibindings.Multibinder;
+
+import org.eclipse.che.api.agent.shared.model.Agent;
+import org.eclipse.che.inject.DynaModule;
+
+/**
+ *
+ */
+@DynaModule
+public class SampleAgentModule extends AbstractModule {
+    @Override
+    protected void configure() {
+        Multibinder.newSetBinder(binder(), Agent.class).addBinding().to(SampleAgent.class);
+    }
+}

--- a/che-agent-archetype/src/main/resources/archetype-resources/agents/__rootArtifactId__/src/main/resources/__groupId__.sample.json
+++ b/che-agent-archetype/src/main/resources/archetype-resources/agents/__rootArtifactId__/src/main/resources/__groupId__.sample.json
@@ -1,0 +1,11 @@
+#set( $symbol_pound = '#' )
+#set( $symbol_dollar = '$' )
+#set( $symbol_escape = '\' )
+{
+  "id": "${groupId}.sample",
+  "name": "Sample agent",
+  "description": "Sample agent",
+  "dependencies": [],
+  "properties": {},
+  "servers": {}
+}

--- a/che-agent-archetype/src/main/resources/archetype-resources/agents/__rootArtifactId__/src/main/resources/__groupId__.sample.script.sh
+++ b/che-agent-archetype/src/main/resources/archetype-resources/agents/__rootArtifactId__/src/main/resources/__groupId__.sample.script.sh
@@ -1,0 +1,109 @@
+#
+# Copyright (c) 2012-2017 Codenvy, S.A.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#   Codenvy, S.A. - initial API and implementation
+#
+
+unset SUDO
+unset PACKAGES
+test "$(id -u)" = 0 || SUDO="sudo -E"
+
+if [ -f /etc/centos-release ]; then
+    FILE="/etc/centos-release"
+    LINUX_TYPE=$(cat $FILE | awk '{print $1}')
+ elif [ -f /etc/redhat-release ]; then
+    FILE="/etc/redhat-release"
+    LINUX_TYPE=$(cat $FILE | cut -c 1-8)
+ else
+    FILE="/etc/os-release"
+    LINUX_TYPE=$(cat $FILE | grep ^ID= | tr '[:upper:]' '[:lower:]')
+    LINUX_VERSION=$(cat $FILE | grep ^VERSION_ID=)
+fi
+
+###############################
+### Install Needed packaged ###
+###############################
+
+# Red Hat Enterprise Linux 7 
+############################
+if echo ${LINUX_TYPE} | grep -qi "rhel"; then
+    test "${PACKAGES}" = "" || {
+        ${SUDO} yum -y install ${PACKAGES};
+    }
+
+# Red Hat Enterprise Linux 6 
+############################
+elif echo ${LINUX_TYPE} | grep -qi "Red Hat"; then
+    test "${PACKAGES}" = "" || {
+        ${SUDO} yum -y install ${PACKAGES};
+    }
+
+# Ubuntu 14.04 16.04 / Linux Mint 17 
+####################################
+elif echo ${LINUX_TYPE} | grep -qi "ubuntu"; then
+    test "${PACKAGES}" = "" || {
+       ${SUDO} apt-get update;
+       ${SUDO} apt-get -y install ${PACKAGES};
+    }
+
+# Debian 8
+##########
+elif echo ${LINUX_TYPE} | grep -qi "debian"; then
+    test "${PACKAGES}" = "" || {
+       ${SUDO} apt-get update;
+       ${SUDO} apt-get -y install ${PACKAGES};
+    }
+
+# Fedora 23
+###########
+elif echo ${LINUX_TYPE} | grep -qi "fedora"; then
+    command -v ps >/dev/null 2>&1 || { PACKAGES=${PACKAGES}" procps-ng"; }
+    test "${PACKAGES}" = "" || {
+       ${SUDO} dnf -y install ${PACKAGES};
+    }
+
+# CentOS 7.1 & Oracle Linux 7.1
+###############################
+elif echo ${LINUX_TYPE} | grep -qi "centos"; then
+    test "${PACKAGES}" = "" || {
+       ${SUDO} yum -y install ${PACKAGES};
+    }
+
+# openSUSE 13.2
+###############
+elif echo ${LINUX_TYPE} | grep -qi "opensuse"; then
+    test "${PACKAGES}" = "" || {
+       ${SUDO} zypper install -y ${PACKAGES};
+    }
+
+# Alpine 3.3
+############
+elif echo ${LINUX_TYPE} | grep -qi "alpine"; then
+    test "${PACKAGES}" = "" || {
+        ${SUDO} apk update;
+        ${SUDO} apk add openssh ${PACKAGES};
+    }
+
+# Centos 6.6, 6.7, 6.8
+############
+elif echo ${LINUX_TYPE} | grep -qi "CentOS"; then
+    test "${PACKAGES}" = "" || {
+        ${SUDO} yum -y install ${PACKAGES};
+    }
+
+else
+    >&2 echo "Unrecognized Linux Type"
+    >&2 cat $FILE
+    exit 1
+fi
+
+#############
+#
+echo "Hello, agent!"
+
+

--- a/che-agent-archetype/src/main/resources/archetype-resources/agents/pom.xml
+++ b/che-agent-archetype/src/main/resources/archetype-resources/agents/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2012-2017 Codenvy, S.A.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Codenvy, S.A. - initial API and implementation
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>${rootArtifactId}</artifactId>
+        <groupId>${groupId}</groupId>
+        <version>${version}</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <artifactId>che-agents-parent</artifactId>
+    <packaging>pom</packaging>
+    <name>Che :: Agents :: Parent</name>
+</project>

--- a/che-agent-archetype/src/main/resources/archetype-resources/assembly/assembly-main/pom.xml
+++ b/che-agent-archetype/src/main/resources/archetype-resources/assembly/assembly-main/pom.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2012-2017 Codenvy, S.A.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Codenvy, S.A. - initial API and implementation
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>che-assembly-parent</artifactId>
+        <groupId>${groupId}</groupId>
+        <version>${version}</version>
+    </parent>
+    <artifactId>${artifactId}</artifactId>
+    <packaging>pom</packaging>
+    <name>Che IDE :: Assemblies Tomcat</name>
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.che</groupId>
+            <artifactId>assembly-main</artifactId>
+            <type>zip</type>
+        </dependency>
+        <dependency>
+            <groupId>${groupId}</groupId>
+            <artifactId>assembly-wsmaster-war</artifactId>
+            <type>war</type>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <appendAssemblyId>false</appendAssemblyId>
+                    <updateOnly>false</updateOnly>
+                    <descriptor>${project.basedir}/src/assembly/assembly.xml</descriptor>
+                    <finalName>eclipse-che-${project.version}</finalName>
+                    <tarLongFileMode>posix</tarLongFileMode>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>unpack-tomcat</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.eclipse.che</groupId>
+                                    <artifactId>assembly-main</artifactId>
+                                    <type>zip</type>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>${project.build.directory}/dependency</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/che-agent-archetype/src/main/resources/archetype-resources/assembly/assembly-main/src/assembly/assembly.xml
+++ b/che-agent-archetype/src/main/resources/archetype-resources/assembly/assembly-main/src/assembly/assembly.xml
@@ -1,0 +1,45 @@
+#set( $symbol_pound = '#' )
+#set( $symbol_dollar = '$' )
+#set( $symbol_escape = '\' )
+<!--
+
+    Copyright (c) 2012-2017 Codenvy, S.A.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Codenvy, S.A. - initial API and implementation
+
+-->
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+    <id>tomcat-zip</id>
+    <formats>
+        <format>dir</format>
+        <format>zip</format>
+        <format>tar.gz</format>
+    </formats>
+    <dependencySets>
+        <dependencySet>
+            <useProjectArtifact>false</useProjectArtifact>
+            <unpack>false</unpack>
+            <outputDirectory>tomcat/webapps</outputDirectory>
+            <outputFileNameMapping>wsmaster.war</outputFileNameMapping>
+            <includes>
+                <include>${groupId}:assembly-wsmaster-war</include>
+            </includes>
+        </dependencySet>
+    </dependencySets>
+
+    <fileSets>
+        <fileSet>
+            <directory>${symbol_dollar}{project.build.directory}/dependency/eclipse-che-${symbol_dollar}{che.version}</directory>
+            <outputDirectory></outputDirectory>
+            <excludes>
+                <exclude>**/tomcat/webapps/wsmaster.war</exclude>
+            </excludes>
+        </fileSet>
+    </fileSets>
+</assembly>

--- a/che-agent-archetype/src/main/resources/archetype-resources/assembly/assembly-wsmaster-war/pom.xml
+++ b/che-agent-archetype/src/main/resources/archetype-resources/assembly/assembly-wsmaster-war/pom.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2012-2017 Codenvy, S.A.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Codenvy, S.A. - initial API and implementation
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>che-assembly-parent</artifactId>
+        <groupId>${groupId}</groupId>
+        <version>${version}</version>
+    </parent>
+    <artifactId>${artifactId}</artifactId>
+    <packaging>war</packaging>
+    <name>Che IDE :: Compiling WS Master WAR</name>
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.che</groupId>
+            <artifactId>assembly-wsmaster-war</artifactId>
+            <type>war</type>
+        </dependency>
+        <dependency>
+            <groupId>${groupId}</groupId>
+            <artifactId>sample-agent</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>javax.servlet-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>analyze</id>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <configuration>
+                    <overlays>
+                        <overlay>
+                            <groupId>org.eclipse.che</groupId>
+                            <artifactId>assembly-wsmaster-war</artifactId>
+                            <type>war</type>
+                            <includes>
+                                <include>**/**</include>
+                                <include>META-INF/context.xml</include>
+                                <include>META-INF/web.xml</include>
+                            </includes>
+                        </overlay>
+                    </overlays>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/che-agent-archetype/src/main/resources/archetype-resources/assembly/pom.xml
+++ b/che-agent-archetype/src/main/resources/archetype-resources/assembly/pom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2012-2017 Codenvy, S.A.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Codenvy, S.A. - initial API and implementation
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>${rootArtifactId}</artifactId>
+        <groupId>${groupId}</groupId>
+        <version>${version}</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <artifactId>${artifactId}</artifactId>
+    <packaging>pom</packaging>
+    <name>Che IDE :: Parent</name>
+</project>

--- a/che-agent-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/che-agent-archetype/src/main/resources/archetype-resources/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>maven-depmgt-pom</artifactId>
         <groupId>org.eclipse.che.depmgt</groupId>
-        <version>5.2.0-SNAPSHOT</version>
+        <version>5.3.0-SNAPSHOT</version>
     </parent>
     <groupId>${groupId}</groupId>
     <artifactId>${artifactId}</artifactId>

--- a/che-agent-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/che-agent-archetype/src/main/resources/archetype-resources/pom.xml
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2012-2017 Codenvy, S.A.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Codenvy, S.A. - initial API and implementation
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>maven-depmgt-pom</artifactId>
+        <groupId>org.eclipse.che.depmgt</groupId>
+        <version>5.2.0-SNAPSHOT</version>
+    </parent>
+    <groupId>${groupId}</groupId>
+    <artifactId>${artifactId}</artifactId>
+    <version>${version}</version>
+    <packaging>pom</packaging>
+    <name>Che :: Parent</name>
+    <url>https://www.eclipse.org/che/</url>
+    <licenses>
+        <license>
+            <name>Eclipse Public License v1.0</name>
+            <url>http://www.eclipse.org/legal/epl-v10.html</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+    <properties>
+        <che.version>${che}</che.version>
+    </properties>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.eclipse.che</groupId>
+                <artifactId>assembly-main</artifactId>
+                <type>zip</type>
+                <version>${che.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.che</groupId>
+                <artifactId>assembly-wsmaster-war</artifactId>
+                <type>war</type>
+                <version>${che.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.che.core</groupId>
+                <artifactId>che-core-api-agent-shared</artifactId>
+                <version>${che.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.che.core</groupId>
+                <artifactId>che-core-commons-inject</artifactId>
+                <version>${che.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${groupId}</groupId>
+                <artifactId>sample-agent</artifactId>
+                <version>${version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${groupId}</groupId>
+                <artifactId>assembly-main</artifactId>
+                <type>tar.gz</type>
+                <version>${version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${groupId}</groupId>
+                <artifactId>assembly-main</artifactId>
+                <type>zip</type>
+                <version>${version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${groupId}</groupId>
+                <artifactId>assembly-wsmaster-war</artifactId>
+                <type>war</type>
+                <version>${version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+    <repositories>
+        <repository>
+            <id>codenvy-public-repo</id>
+            <name>codenvy public</name>
+            <url>https://maven.codenvycorp.com/content/groups/public/</url>
+        </repository>
+        <repository>
+            <id>codenvy-public-snapshots-repo</id>
+            <name>codenvy public snapshots</name>
+            <url>https://maven.codenvycorp.com/content/repositories/codenvy-public-snapshots/</url>
+        </repository>
+    </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>codenvy-public-repo</id>
+            <name>codenvy public</name>
+            <url>https://maven.codenvycorp.com/content/groups/public/</url>
+        </pluginRepository>
+        <pluginRepository>
+            <id>codenvy-public-snapshots-repo</id>
+            <name>codenvy public snapshots</name>
+            <url>https://maven.codenvycorp.com/content/repositories/codenvy-public-snapshots/</url>
+        </pluginRepository>
+    </pluginRepositories>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>**/*.*</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>com.google.code.sortpom</groupId>
+                <artifactId>maven-sortpom-plugin</artifactId>
+                <version>${version.sortpom.plugin}</version>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/che-agent-archetype/src/test/resources/projects/basic/archetype.properties
+++ b/che-agent-archetype/src/test/resources/projects/basic/archetype.properties
@@ -14,4 +14,4 @@ package=it.pkg
 version=0.1-SNAPSHOT
 groupId=archetype.it
 artifactId=myagent
-che=5.2.0
+che=5.3.0-SNAPSHOT

--- a/che-agent-archetype/src/test/resources/projects/basic/archetype.properties
+++ b/che-agent-archetype/src/test/resources/projects/basic/archetype.properties
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2012-2017 Codenvy, S.A.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#   Codenvy, S.A. - initial API and implementation
+#
+
+
+package=it.pkg
+version=0.1-SNAPSHOT
+groupId=archetype.it
+artifactId=myagent
+che=5.2.0

--- a/che-agent-archetype/src/test/resources/projects/basic/goal.txt
+++ b/che-agent-archetype/src/test/resources/projects/basic/goal.txt
@@ -1,0 +1,1 @@
+clean install

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>maven-depmgt-pom</artifactId>
         <groupId>org.eclipse.che.depmgt</groupId>
-        <version>5.1.0</version>
+        <version>5.3.0-SNAPSHOT</version>
     </parent>
     <groupId>org.eclipse.che.archetype</groupId>
     <artifactId>eclipse-che-archetype-parent</artifactId>
@@ -34,6 +34,7 @@
     <modules>
         <module>che-plugin-ide-menu-archetype</module>
         <module>che-plugin-ide-wizard-archetype</module>
+        <module>che-agent-archetype</module>
     </modules>
     <dependencyManagement>
         <dependencies />


### PR DESCRIPTION
### Reference issue
https://github.com/eclipse/che/issues/3959

### Changelog and Release Note Information

**Changelog:** Create archetype to add new custom agent that is not language server
**Release Notes:** 
Archetype for adding a new custom agent.
Run command bellow to initialize folder with sample agent and custom assembly:
```
mvn archetype:generate                                                      \
  -DarchetypeRepository=http://maven.codenvycorp.com/content/groups/public/ \
  -DarchetypeGroupId=org.eclipse.che.archetype                              \
  -DarchetypeArtifactId=che-agent-archetype                                 \
  -DarchetypeVersion=<ARCHETYPE_VERSION>                                    \
  -DcheVersion=<CHE_VERSION>                                                \
  -DgroupId=my.agent                                                        \
  -DartifactId=agent-sample                                                 \
  -Dversion=0.1-SNAPSHOT
```
Run `mvn clean install` to build assembly and user che cli to run it.

### Docs PR:
https://github.com/eclipse/che-docs/pull/125