### PR TITLE
Add che.version property for archetypes

### DIFF
--- a/che-agent-archetype/pom.xml
+++ b/che-agent-archetype/pom.xml
@@ -98,7 +98,7 @@
                         </goals>
                         <configuration>
                             <tasks>
-                                <replace dir="${basedir}/target" token="$${cheVersion}" value="${che.version}" />
+                                <replace dir="${project.build.outputDirectory}/archetype-resources" token="$${cheVersion}" value="${che.version}" />
                             </tasks>
                         </configuration>
                     </execution>

--- a/che-agent-archetype/pom.xml
+++ b/che-agent-archetype/pom.xml
@@ -23,6 +23,9 @@
     <packaging>maven-archetype</packaging>
     <name>che-agent-archetype</name>
     <description>Contains sample Agent, that outputs 'Hello, Agent!' on workspace startup</description>
+    <properties>
+        <che.version>5.3.0-SNAPSHOT</che.version>
+    </properties>
     <build>
         <extensions>
             <extension>
@@ -85,6 +88,22 @@
                                     </outputDirectory>
                                 </artifactItem>
                             </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <tasks>
+                                <replace dir="${basedir}/target" token="@che.version@" value ="${che.version}"></replace>
+                            </tasks>
                         </configuration>
                     </execution>
                 </executions>

--- a/che-agent-archetype/pom.xml
+++ b/che-agent-archetype/pom.xml
@@ -23,9 +23,6 @@
     <packaging>maven-archetype</packaging>
     <name>che-agent-archetype</name>
     <description>Contains sample Agent, that outputs 'Hello, Agent!' on workspace startup</description>
-    <properties>
-        <che.version>5.3.0-SNAPSHOT</che.version>
-    </properties>
     <build>
         <extensions>
             <extension>
@@ -84,8 +81,7 @@
                                 <artifactItem>
                                     <groupId>org.eclipse.che.archetype</groupId>
                                     <artifactId>che-archetype-resources</artifactId>
-                                    <outputDirectory>${project.build.outputDirectory}/archetype-resources
-                                    </outputDirectory>
+                                    <outputDirectory>${project.build.outputDirectory}/archetype-resources</outputDirectory>
                                 </artifactItem>
                             </artifactItems>
                         </configuration>
@@ -102,7 +98,7 @@
                         </goals>
                         <configuration>
                             <tasks>
-                                <replace dir="${basedir}/target" token="@che.version@" value ="${che.version}"></replace>
+                                <replace dir="${basedir}/target" token="$${cheVersion}" value="${che.version}" />
                             </tasks>
                         </configuration>
                     </execution>

--- a/che-agent-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/che-agent-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -16,11 +16,6 @@
         name="agent-parent"
         xmlns="http://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.0.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-    <requiredProperties>
-        <requiredProperty key="cheVersion">
-            <defaultValue>5.3.0-SNAPSHOT</defaultValue>
-        </requiredProperty>
-    </requiredProperties>
     <fileSets>
         <fileSet filtered="false" encoding="UTF-8">
             <directory></directory>

--- a/che-agent-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/che-agent-archetype/src/main/resources/archetype-resources/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <artifactId>maven-depmgt-pom</artifactId>
         <groupId>org.eclipse.che.depmgt</groupId>
-        <version>@che.version@</version>
+        <version>${cheVersion}</version>
     </parent>
     <groupId>${groupId}</groupId>
     <artifactId>${artifactId}</artifactId>
@@ -30,7 +30,7 @@
         </license>
     </licenses>
     <properties>
-        <che.version>@che.version@</che.version>
+        <che.version>${cheVersion}</che.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/che-agent-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/che-agent-archetype/src/main/resources/archetype-resources/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <artifactId>maven-depmgt-pom</artifactId>
         <groupId>org.eclipse.che.depmgt</groupId>
-        <version>5.3.0-SNAPSHOT</version>
+        <version>@che.version@</version>
     </parent>
     <groupId>${groupId}</groupId>
     <artifactId>${artifactId}</artifactId>
@@ -30,7 +30,7 @@
         </license>
     </licenses>
     <properties>
-        <che.version>${cheVersion}</che.version>
+        <che.version>@che.version@</che.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/che-agent-archetype/src/test/resources/projects/basic/archetype.properties
+++ b/che-agent-archetype/src/test/resources/projects/basic/archetype.properties
@@ -14,4 +14,3 @@ package=it.pkg
 version=0.1-SNAPSHOT
 groupId=archetype.it
 artifactId=myagent
-cheVersion=5.3.0-SNAPSHOT

--- a/che-plugin-ide-menu-archetype/pom.xml
+++ b/che-plugin-ide-menu-archetype/pom.xml
@@ -98,7 +98,7 @@
                         </goals>
                         <configuration>
                             <tasks>
-                                <replace dir="${basedir}/target" token="$${cheVersion}" value="${che.version}" />
+                                <replace dir="${project.build.outputDirectory}/archetype-resources" token="$${cheVersion}" value="${che.version}" />
                             </tasks>
                         </configuration>
                     </execution>

--- a/che-plugin-ide-menu-archetype/pom.xml
+++ b/che-plugin-ide-menu-archetype/pom.xml
@@ -23,9 +23,6 @@
     <packaging>maven-archetype</packaging>
     <name>che-plugin-ide-menu-archetype</name>
     <description>Contains sample menu entry with 'Say hello' action that pops up a notification</description>
-    <properties>
-        <che.version>5.3.0-SNAPSHOT</che.version>
-    </properties>
     <build>
         <extensions>
             <extension>
@@ -101,7 +98,7 @@
                         </goals>
                         <configuration>
                             <tasks>
-                                <replace dir="${basedir}/target" token="@che.version@" value ="${che.version}"></replace>
+                                <replace dir="${basedir}/target" token="$${cheVersion}" value="${che.version}" />
                             </tasks>
                         </configuration>
                     </execution>

--- a/che-plugin-ide-menu-archetype/pom.xml
+++ b/che-plugin-ide-menu-archetype/pom.xml
@@ -23,6 +23,9 @@
     <packaging>maven-archetype</packaging>
     <name>che-plugin-ide-menu-archetype</name>
     <description>Contains sample menu entry with 'Say hello' action that pops up a notification</description>
+    <properties>
+        <che.version>5.3.0-SNAPSHOT</che.version>
+    </properties>
     <build>
         <extensions>
             <extension>
@@ -84,6 +87,22 @@
                                     <outputDirectory>${project.build.outputDirectory}/archetype-resources</outputDirectory>
                                 </artifactItem>
                             </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <tasks>
+                                <replace dir="${basedir}/target" token="@che.version@" value ="${che.version}"></replace>
+                            </tasks>
                         </configuration>
                     </execution>
                 </executions>

--- a/che-plugin-ide-menu-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/che-plugin-ide-menu-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -16,11 +16,6 @@
         name="wizard-parent"
         xmlns="http://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.0.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-    <requiredProperties>
-        <requiredProperty key="cheVersion">
-            <defaultValue>5.3.0-SNAPSHOT</defaultValue>
-        </requiredProperty>
-    </requiredProperties>
     <fileSets>
         <fileSet filtered="false" encoding="UTF-8">
             <directory></directory>

--- a/che-plugin-ide-menu-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/che-plugin-ide-menu-archetype/src/main/resources/archetype-resources/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <artifactId>maven-depmgt-pom</artifactId>
         <groupId>org.eclipse.che.depmgt</groupId>
-        <version>5.3.0-SNAPSHOT</version>
+        <version>${cheVersion}</version>
     </parent>
     <groupId>${groupId}</groupId>
     <artifactId>${artifactId}</artifactId>
@@ -30,7 +30,7 @@
         </license>
     </licenses>
     <properties>
-        <che.version>@che.version@</che.version>
+        <che.version>${cheVersion}</che.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/che-plugin-ide-menu-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/che-plugin-ide-menu-archetype/src/main/resources/archetype-resources/pom.xml
@@ -30,7 +30,7 @@
         </license>
     </licenses>
     <properties>
-        <che.version>${cheVersion}</che.version>
+        <che.version>@che.version@</che.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/che-plugin-ide-menu-archetype/src/test/resources/projects/basic/archetype.properties
+++ b/che-plugin-ide-menu-archetype/src/test/resources/projects/basic/archetype.properties
@@ -14,5 +14,3 @@ package=it.pkg
 version=0.1-SNAPSHOT
 groupId=archetype.it
 artifactId=plugin-mywizard
-cheVersion=5.3.0-SNAPSHOT
-

--- a/che-plugin-ide-wizard-archetype/pom.xml
+++ b/che-plugin-ide-wizard-archetype/pom.xml
@@ -98,7 +98,7 @@
                         </goals>
                         <configuration>
                             <tasks>
-                                <replace dir="${basedir}/target" token="$${cheVersion}" value="${che.version}" />
+                                <replace dir="${project.build.outputDirectory}/archetype-resources" token="$${cheVersion}" value="${che.version}" />
                             </tasks>
                         </configuration>
                     </execution>

--- a/che-plugin-ide-wizard-archetype/pom.xml
+++ b/che-plugin-ide-wizard-archetype/pom.xml
@@ -23,6 +23,9 @@
     <packaging>maven-archetype</packaging>
     <name>che-plugin-ide-wizard-archetype</name>
     <description>Contains sample project type, based on C language, as well as action to create new .c files</description>
+    <properties>
+        <che.version>5.3.0-SNAPSHOT</che.version>
+    </properties>
     <build>
         <extensions>
             <extension>
@@ -85,6 +88,22 @@
                                     </outputDirectory>
                                 </artifactItem>
                             </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <tasks>
+                                <replace dir="${basedir}/target" token="@che.version@" value ="${che.version}"></replace>
+                            </tasks>
                         </configuration>
                     </execution>
                 </executions>

--- a/che-plugin-ide-wizard-archetype/pom.xml
+++ b/che-plugin-ide-wizard-archetype/pom.xml
@@ -23,9 +23,6 @@
     <packaging>maven-archetype</packaging>
     <name>che-plugin-ide-wizard-archetype</name>
     <description>Contains sample project type, based on C language, as well as action to create new .c files</description>
-    <properties>
-        <che.version>5.3.0-SNAPSHOT</che.version>
-    </properties>
     <build>
         <extensions>
             <extension>
@@ -84,8 +81,7 @@
                                 <artifactItem>
                                     <groupId>org.eclipse.che.archetype</groupId>
                                     <artifactId>che-archetype-resources</artifactId>
-                                    <outputDirectory>${project.build.outputDirectory}/archetype-resources
-                                    </outputDirectory>
+                                    <outputDirectory>${project.build.outputDirectory}/archetype-resources</outputDirectory>
                                 </artifactItem>
                             </artifactItems>
                         </configuration>
@@ -102,7 +98,7 @@
                         </goals>
                         <configuration>
                             <tasks>
-                                <replace dir="${basedir}/target" token="@che.version@" value ="${che.version}"></replace>
+                                <replace dir="${basedir}/target" token="$${cheVersion}" value="${che.version}" />
                             </tasks>
                         </configuration>
                     </execution>

--- a/che-plugin-ide-wizard-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/che-plugin-ide-wizard-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -16,11 +16,6 @@
         name="wizard-parent"
         xmlns="http://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.0.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-    <requiredProperties>
-        <requiredProperty key="cheVersion">
-            <defaultValue>5.3.0-SNAPSHOT</defaultValue>
-        </requiredProperty>
-    </requiredProperties>
     <fileSets>
         <fileSet filtered="false" encoding="UTF-8">
             <directory></directory>

--- a/che-plugin-ide-wizard-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/che-plugin-ide-wizard-archetype/src/main/resources/archetype-resources/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <artifactId>maven-depmgt-pom</artifactId>
         <groupId>org.eclipse.che.depmgt</groupId>
-        <version>5.3.0-SNAPSHOT</version>
+        <version>${cheVersion}</version>
     </parent>
     <groupId>${groupId}</groupId>
     <artifactId>${artifactId}</artifactId>
@@ -30,7 +30,7 @@
         </license>
     </licenses>
     <properties>
-        <che.version>@che.version@</che.version>
+        <che.version>${cheVersion}</che.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/che-plugin-ide-wizard-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/che-plugin-ide-wizard-archetype/src/main/resources/archetype-resources/pom.xml
@@ -30,7 +30,7 @@
         </license>
     </licenses>
     <properties>
-        <che.version>${cheVersion}</che.version>
+        <che.version>@che.version@</che.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/che-plugin-ide-wizard-archetype/src/test/resources/projects/basic/archetype.properties
+++ b/che-plugin-ide-wizard-archetype/src/test/resources/projects/basic/archetype.properties
@@ -14,4 +14,3 @@ package=it.pkg
 version=0.1-SNAPSHOT
 groupId=archetype.it
 artifactId=plugin-mywizard
-cheVersion=5.3.0-SNAPSHOT

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
         <module>che-agent-archetype</module>
     </modules>
     <properties>
+        <che.version>5.3.0-SNAPSHOT</che.version>
         <version.archetype.plugin>2.4</version.archetype.plugin>
     </properties>
     <dependencyManagement>


### PR DESCRIPTION
`che.version` property is now defined in archetypes parent. It is used for Che dependencies versions in archetypes

### Changelog
Adds `che.version` property definition to archetypes parent to help with dependencies.

### Release Notes and Docs
N/A