### PR TITLE
Migration to minimal IDE assembly of all  archetypes

### DIFF
--- a/plugin-embedjs-archetype/src/main/resources/archetype-resources/assembly-che/assembly-ide-war/pom.xml
+++ b/plugin-embedjs-archetype/src/main/resources/archetype-resources/assembly-che/assembly-ide-war/pom.xml
@@ -25,9 +25,8 @@
     </properties>
     <dependencies>
         <dependency>
-            <groupId>org.eclipse.che</groupId>
-            <artifactId>assembly-ide-war</artifactId>
-            <classifier>classes</classifier>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-ide-core</artifactId>
         </dependency>
         <dependency>
             <groupId>${groupId}</groupId>

--- a/plugin-embedjs-archetype/src/main/resources/archetype-resources/assembly-codenvy/assembly-ide-war/pom.xml
+++ b/plugin-embedjs-archetype/src/main/resources/archetype-resources/assembly-codenvy/assembly-ide-war/pom.xml
@@ -26,8 +26,7 @@
     <dependencies>
         <dependency>
             <groupId>com.codenvy.onpremises</groupId>
-            <artifactId>compiling-ide-war</artifactId>
-            <classifier>classes</classifier>
+            <artifactId>codenvy-ide-core</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/plugin-embedjs-archetype/src/main/resources/archetype-resources/plugins/__rootArtifactId__/__rootArtifactId__-ide/src/main/java/__packageInPathFormat__/ide/view/HelloWorldViewImpl.ui.xml
+++ b/plugin-embedjs-archetype/src/main/resources/archetype-resources/plugins/__rootArtifactId__/__rootArtifactId__-ide/src/main/java/__packageInPathFormat__/ide/view/HelloWorldViewImpl.ui.xml
@@ -10,8 +10,6 @@
 <ui:UiBinder xmlns:ui='urn:ui:com.google.gwt.uibinder'
              xmlns:g='urn:import:com.google.gwt.user.client.ui'>
 
-    <ui:with field="locale" type="org.eclipse.che.ide.extension.machine.client.MachineLocalizationConstant"/>
-
     <ui:style>
 
         @eval outputBackgroundColor org.eclipse.che.ide.api.theme.Style.theme.outputBackgroundColor();

--- a/plugin-menu-archetype/src/main/resources/archetype-resources/assembly-che/assembly-ide-war/pom.xml
+++ b/plugin-menu-archetype/src/main/resources/archetype-resources/assembly-che/assembly-ide-war/pom.xml
@@ -25,9 +25,8 @@
     </properties>
     <dependencies>
         <dependency>
-            <groupId>org.eclipse.che</groupId>
-            <artifactId>assembly-ide-war</artifactId>
-            <classifier>classes</classifier>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-ide-core</artifactId>
         </dependency>
         <dependency>
             <groupId>${groupId}</groupId>

--- a/plugin-menu-archetype/src/main/resources/archetype-resources/assembly-codenvy/assembly-ide-war/pom.xml
+++ b/plugin-menu-archetype/src/main/resources/archetype-resources/assembly-codenvy/assembly-ide-war/pom.xml
@@ -26,8 +26,7 @@
     <dependencies>
         <dependency>
             <groupId>com.codenvy.onpremises</groupId>
-            <artifactId>compiling-ide-war</artifactId>
-            <classifier>classes</classifier>
+            <artifactId>codenvy-ide-core</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/plugin-serverservice-archetype/src/main/resources/archetype-resources/assembly-che/assembly-ide-war/pom.xml
+++ b/plugin-serverservice-archetype/src/main/resources/archetype-resources/assembly-che/assembly-ide-war/pom.xml
@@ -25,9 +25,8 @@
     </properties>
     <dependencies>
         <dependency>
-            <groupId>org.eclipse.che</groupId>
-            <artifactId>assembly-ide-war</artifactId>
-            <classifier>classes</classifier>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-ide-core</artifactId>
         </dependency>
         <dependency>
             <groupId>${groupId}</groupId>

--- a/plugin-serverservice-archetype/src/main/resources/archetype-resources/assembly-codenvy/assembly-ide-war/pom.xml
+++ b/plugin-serverservice-archetype/src/main/resources/archetype-resources/assembly-codenvy/assembly-ide-war/pom.xml
@@ -26,8 +26,7 @@
     <dependencies>
         <dependency>
             <groupId>com.codenvy.onpremises</groupId>
-            <artifactId>compiling-ide-war</artifactId>
-            <classifier>classes</classifier>
+            <artifactId>codenvy-ide-core</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/plugin-wizard-archetype/src/main/resources/archetype-resources/assembly-che/assembly-ide-war/pom.xml
+++ b/plugin-wizard-archetype/src/main/resources/archetype-resources/assembly-che/assembly-ide-war/pom.xml
@@ -25,9 +25,8 @@
     </properties>
     <dependencies>
         <dependency>
-            <groupId>org.eclipse.che</groupId>
-            <artifactId>assembly-ide-war</artifactId>
-            <classifier>classes</classifier>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-ide-core</artifactId>
         </dependency>
         <dependency>
             <groupId>${groupId}</groupId>

--- a/plugin-wizard-archetype/src/main/resources/archetype-resources/assembly-che/assembly-wsagent-war/pom.xml
+++ b/plugin-wizard-archetype/src/main/resources/archetype-resources/assembly-che/assembly-wsagent-war/pom.xml
@@ -20,17 +20,13 @@
     <name>Wizard Sample :: Che Assembly :: Workspace Agent War Packaging</name>
     <dependencies>
         <dependency>
-            <groupId>org.eclipse.che</groupId>
-            <artifactId>assembly-wsagent-war</artifactId>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-wsagent-core</artifactId>
             <type>war</type>
         </dependency>
         <dependency>
             <groupId>${groupId}</groupId>
             <artifactId>plugin-wizard-server</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>${groupId}</groupId>
-            <artifactId>plugin-wizard-shared</artifactId>
         </dependency>
     </dependencies>
     <build>

--- a/plugin-wizard-archetype/src/main/resources/archetype-resources/assembly-codenvy/assembly-ide-war/pom.xml
+++ b/plugin-wizard-archetype/src/main/resources/archetype-resources/assembly-codenvy/assembly-ide-war/pom.xml
@@ -26,8 +26,7 @@
     <dependencies>
         <dependency>
             <groupId>com.codenvy.onpremises</groupId>
-            <artifactId>compiling-ide-war</artifactId>
-            <classifier>classes</classifier>
+            <artifactId>codenvy-ide-core</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/plugin-wizard-archetype/src/main/resources/archetype-resources/assembly-codenvy/assembly-wsagent-war/pom.xml
+++ b/plugin-wizard-archetype/src/main/resources/archetype-resources/assembly-codenvy/assembly-wsagent-war/pom.xml
@@ -20,17 +20,13 @@
     <name>Wizard Sample :: Codenvy Assembly :: Workspace Agent War Packaging</name>
     <dependencies>
         <dependency>
-            <groupId>com.codenvy.onpremises</groupId>
-            <artifactId>assembly-wsagent-war</artifactId>
+            <groupId>com.codenvy.onpremises.wsagent</groupId>
+            <artifactId>codenvy-wsagent-core</artifactId>
             <type>war</type>
         </dependency>
         <dependency>
             <groupId>${groupId}</groupId>
             <artifactId>plugin-wizard-server</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>${groupId}</groupId>
-            <artifactId>plugin-wizard-shared</artifactId>
         </dependency>
     </dependencies>
     <build>


### PR DESCRIPTION
This pr https://github.com/eclipse/che-archetypes/pull/44 is made only Plugin-json on basic assembly.  Current pr make all archetypes generate samples based on basic assembly

Related to https://github.com/eclipse/che/issues/4403

Changelog
All archetypes migrated to minimal IDE assembly

Release Notes
All archetypes migrated to minimal IDE assembly

Docs PR
N/A