### PR TITLE
Apply changes for new maven plugin updates

### DIFF
--- a/agent-archetype/src/main/resources/archetype-resources/assembly-che/assembly-main/pom.xml
+++ b/agent-archetype/src/main/resources/archetype-resources/assembly-che/assembly-main/pom.xml
@@ -43,7 +43,9 @@
                 <configuration>
                     <appendAssemblyId>false</appendAssemblyId>
                     <updateOnly>false</updateOnly>
-                    <descriptor>${project.basedir}/src/assembly/assembly.xml</descriptor>
+                    <descriptors>
+                        <descriptor>${project.basedir}/src/assembly/assembly.xml</descriptor>
+                    </descriptors>
                     <finalName>eclipse-che-${project.version}</finalName>
                     <tarLongFileMode>posix</tarLongFileMode>
                 </configuration>

--- a/agent-archetype/src/main/resources/archetype-resources/assembly-codenvy/assembly-main/pom.xml
+++ b/agent-archetype/src/main/resources/archetype-resources/assembly-codenvy/assembly-main/pom.xml
@@ -41,7 +41,9 @@
                 <configuration>
                     <appendAssemblyId>false</appendAssemblyId>
                     <updateOnly>false</updateOnly>
-                    <descriptor>${project.basedir}/src/assembly/assembly.xml</descriptor>
+                    <descriptors>
+                        <descriptor>${project.basedir}/src/assembly/assembly.xml</descriptor>
+                    </descriptors>
                     <finalName>codenvy-onpremises-${project.version}</finalName>
                     <tarLongFileMode>posix</tarLongFileMode>
                 </configuration>

--- a/plugin-embedjs-archetype/src/main/resources/archetype-resources/assembly-che/assembly-main/pom.xml
+++ b/plugin-embedjs-archetype/src/main/resources/archetype-resources/assembly-che/assembly-main/pom.xml
@@ -42,7 +42,9 @@
                 <configuration>
                     <appendAssemblyId>false</appendAssemblyId>
                     <updateOnly>false</updateOnly>
-                    <descriptor>${project.basedir}/src/assembly/assembly.xml</descriptor>
+                    <descriptors>
+                        <descriptor>${project.basedir}/src/assembly/assembly.xml</descriptor>
+                    </descriptors>
                     <finalName>eclipse-che-${project.version}</finalName>
                     <tarLongFileMode>posix</tarLongFileMode>
                 </configuration>

--- a/plugin-embedjs-archetype/src/main/resources/archetype-resources/assembly-codenvy/assembly-main/pom.xml
+++ b/plugin-embedjs-archetype/src/main/resources/archetype-resources/assembly-codenvy/assembly-main/pom.xml
@@ -42,7 +42,9 @@
                 <configuration>
                     <appendAssemblyId>false</appendAssemblyId>
                     <updateOnly>false</updateOnly>
-                    <descriptor>${project.basedir}/src/assembly/assembly.xml</descriptor>
+                    <descriptors>
+                        <descriptor>${project.basedir}/src/assembly/assembly.xml</descriptor>
+                    </descriptors>
                     <finalName>codenvy-onpremises-${project.version}</finalName>
                     <tarLongFileMode>posix</tarLongFileMode>
                 </configuration>

--- a/plugin-json-archetype/src/main/resources/archetype-resources/assembly-che/assembly-main/pom.xml
+++ b/plugin-json-archetype/src/main/resources/archetype-resources/assembly-che/assembly-main/pom.xml
@@ -47,7 +47,9 @@
                 <configuration>
                     <appendAssemblyId>false</appendAssemblyId>
                     <updateOnly>false</updateOnly>
-                    <descriptor>${project.basedir}/src/assembly/assembly.xml</descriptor>
+                    <descriptors>
+                        <descriptor>${project.basedir}/src/assembly/assembly.xml</descriptor>
+                    </descriptors>
                     <finalName>eclipse-che-${project.version}</finalName>
                     <tarLongFileMode>posix</tarLongFileMode>
                 </configuration>

--- a/plugin-json-archetype/src/main/resources/archetype-resources/assembly-che/assembly-wsagent-server/pom.xml
+++ b/plugin-json-archetype/src/main/resources/archetype-resources/assembly-che/assembly-wsagent-server/pom.xml
@@ -43,7 +43,9 @@
                     <tarLongFileMode>posix</tarLongFileMode>
                     <appendAssemblyId>false</appendAssemblyId>
                     <updateOnly>false</updateOnly>
-                    <descriptor>${project.basedir}/src/assembly/assembly.xml</descriptor>
+                    <descriptors>
+                        <descriptor>${project.basedir}/src/assembly/assembly.xml</descriptor>
+                    </descriptors>
                     <finalName>ext-server-${project.version}</finalName>
                 </configuration>
             </plugin>

--- a/plugin-json-archetype/src/main/resources/archetype-resources/assembly-codenvy/assembly-main/pom.xml
+++ b/plugin-json-archetype/src/main/resources/archetype-resources/assembly-codenvy/assembly-main/pom.xml
@@ -46,7 +46,9 @@
                 <configuration>
                     <appendAssemblyId>false</appendAssemblyId>
                     <updateOnly>false</updateOnly>
-                    <descriptor>${project.basedir}/src/assembly/assembly.xml</descriptor>
+                    <descriptors>
+                        <descriptor>${project.basedir}/src/assembly/assembly.xml</descriptor>
+                    </descriptors>
                     <finalName>codenvy-onpremises-${project.version}</finalName>
                     <tarLongFileMode>posix</tarLongFileMode>
                 </configuration>

--- a/plugin-json-archetype/src/main/resources/archetype-resources/assembly-codenvy/assembly-wsagent-server/pom.xml
+++ b/plugin-json-archetype/src/main/resources/archetype-resources/assembly-codenvy/assembly-wsagent-server/pom.xml
@@ -43,7 +43,9 @@
                     <tarLongFileMode>posix</tarLongFileMode>
                     <appendAssemblyId>false</appendAssemblyId>
                     <updateOnly>false</updateOnly>
-                    <descriptor>${project.basedir}/src/assembly/assembly.xml</descriptor>
+                    <descriptors>
+                        <descriptor>${project.basedir}/src/assembly/assembly.xml</descriptor>
+                    </descriptors>
                     <finalName>assembly-wsagent-server-${project.version}</finalName>
                 </configuration>
             </plugin>

--- a/plugin-json-archetype/src/main/resources/archetype-resources/plugins/__rootArtifactId__/__rootArtifactId__-ide/pom.xml
+++ b/plugin-json-archetype/src/main/resources/archetype-resources/plugins/__rootArtifactId__/__rootArtifactId__-ide/pom.xml
@@ -83,10 +83,10 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <configuration>
-                    <usedDependencies>
+                    <ignoredUnusedDeclaredDependencies>
                         <param>${groupId}:plugin-json-shared</param>
                         <param>org.eclipse.che.core:che-core-ide-app</param>
-                    </usedDependencies>
+                    </ignoredUnusedDeclaredDependencies>
                 </configuration>
             </plugin>
         </plugins>

--- a/plugin-json-archetype/src/main/resources/archetype-resources/plugins/__rootArtifactId__/__rootArtifactId__-server/pom.xml
+++ b/plugin-json-archetype/src/main/resources/archetype-resources/plugins/__rootArtifactId__/__rootArtifactId__-server/pom.xml
@@ -53,9 +53,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <configuration>
-                    <usedDependencies>
+                    <ignoredUnusedDeclaredDependencies>
                         <param>${groupId}:plugin-json-shared</param>
-                    </usedDependencies>
+                    </ignoredUnusedDeclaredDependencies>
                 </configuration>
             </plugin>
         </plugins>

--- a/plugin-menu-archetype/src/main/resources/archetype-resources/assembly-che/assembly-main/pom.xml
+++ b/plugin-menu-archetype/src/main/resources/archetype-resources/assembly-che/assembly-main/pom.xml
@@ -42,7 +42,9 @@
                 <configuration>
                     <appendAssemblyId>false</appendAssemblyId>
                     <updateOnly>false</updateOnly>
-                    <descriptor>${project.basedir}/src/assembly/assembly.xml</descriptor>
+                    <descriptors>
+                        <descriptor>${project.basedir}/src/assembly/assembly.xml</descriptor>
+                    </descriptors>
                     <finalName>eclipse-che-${project.version}</finalName>
                     <tarLongFileMode>posix</tarLongFileMode>
                 </configuration>

--- a/plugin-menu-archetype/src/main/resources/archetype-resources/assembly-codenvy/assembly-main/pom.xml
+++ b/plugin-menu-archetype/src/main/resources/archetype-resources/assembly-codenvy/assembly-main/pom.xml
@@ -42,7 +42,9 @@
                 <configuration>
                     <appendAssemblyId>false</appendAssemblyId>
                     <updateOnly>false</updateOnly>
-                    <descriptor>${project.basedir}/src/assembly/assembly.xml</descriptor>
+                    <descriptors>
+                        <descriptor>${project.basedir}/src/assembly/assembly.xml</descriptor>
+                    </descriptors>
                     <finalName>codenvy-onpremises-${project.version}</finalName>
                     <tarLongFileMode>posix</tarLongFileMode>
                 </configuration>

--- a/plugin-serverservice-archetype/src/main/resources/archetype-resources/assembly-che/assembly-main/pom.xml
+++ b/plugin-serverservice-archetype/src/main/resources/archetype-resources/assembly-che/assembly-main/pom.xml
@@ -47,7 +47,8 @@
                 <configuration>
                     <appendAssemblyId>false</appendAssemblyId>
                     <updateOnly>false</updateOnly>
-                    <descriptor>${project.basedir}/src/assembly/assembly.xml</descriptor>
+                    <descriptors>
+                        <descriptor>${project.basedir}/src/assembly/assembly.xml</descriptor></descriptors>
                     <finalName>eclipse-che-${project.version}</finalName>
                     <tarLongFileMode>posix</tarLongFileMode>
                 </configuration>

--- a/plugin-serverservice-archetype/src/main/resources/archetype-resources/assembly-codenvy/assembly-main/pom.xml
+++ b/plugin-serverservice-archetype/src/main/resources/archetype-resources/assembly-codenvy/assembly-main/pom.xml
@@ -46,7 +46,9 @@
                 <configuration>
                     <appendAssemblyId>false</appendAssemblyId>
                     <updateOnly>false</updateOnly>
-                    <descriptor>${project.basedir}/src/assembly/assembly.xml</descriptor>
+                    <descriptors>
+                        <descriptor>${project.basedir}/src/assembly/assembly.xml</descriptor>
+                    </descriptors>
                     <finalName>codenvy-onpremises-${project.version}</finalName>
                     <tarLongFileMode>posix</tarLongFileMode>
                 </configuration>

--- a/plugin-wizard-archetype/src/main/resources/archetype-resources/assembly-che/assembly-main/pom.xml
+++ b/plugin-wizard-archetype/src/main/resources/archetype-resources/assembly-che/assembly-main/pom.xml
@@ -47,7 +47,9 @@
                 <configuration>
                     <appendAssemblyId>false</appendAssemblyId>
                     <updateOnly>false</updateOnly>
-                    <descriptor>${project.basedir}/src/assembly/assembly.xml</descriptor>
+                    <descriptors>
+                        <descriptor>${project.basedir}/src/assembly/assembly.xml</descriptor>
+                    </descriptors>
                     <finalName>eclipse-che-${project.version}</finalName>
                     <tarLongFileMode>posix</tarLongFileMode>
                 </configuration>

--- a/plugin-wizard-archetype/src/main/resources/archetype-resources/assembly-che/assembly-wsagent-server/pom.xml
+++ b/plugin-wizard-archetype/src/main/resources/archetype-resources/assembly-che/assembly-wsagent-server/pom.xml
@@ -43,7 +43,9 @@
                     <tarLongFileMode>posix</tarLongFileMode>
                     <appendAssemblyId>false</appendAssemblyId>
                     <updateOnly>false</updateOnly>
-                    <descriptor>${project.basedir}/src/assembly/assembly.xml</descriptor>
+                    <descriptors>
+                        <descriptor>${project.basedir}/src/assembly/assembly.xml</descriptor>
+                    </descriptors>
                     <finalName>ext-server-${project.version}</finalName>
                 </configuration>
             </plugin>

--- a/plugin-wizard-archetype/src/main/resources/archetype-resources/assembly-codenvy/assembly-main/pom.xml
+++ b/plugin-wizard-archetype/src/main/resources/archetype-resources/assembly-codenvy/assembly-main/pom.xml
@@ -46,7 +46,9 @@
                 <configuration>
                     <appendAssemblyId>false</appendAssemblyId>
                     <updateOnly>false</updateOnly>
-                    <descriptor>${project.basedir}/src/assembly/assembly.xml</descriptor>
+                    <descriptors>
+                        <descriptor>${project.basedir}/src/assembly/assembly.xml</descriptor>
+                    </descriptors>
                     <finalName>codenvy-onpremises-${project.version}</finalName>
                     <tarLongFileMode>posix</tarLongFileMode>
                 </configuration>

--- a/plugin-wizard-archetype/src/main/resources/archetype-resources/assembly-codenvy/assembly-wsagent-server/pom.xml
+++ b/plugin-wizard-archetype/src/main/resources/archetype-resources/assembly-codenvy/assembly-wsagent-server/pom.xml
@@ -43,7 +43,9 @@
                     <tarLongFileMode>posix</tarLongFileMode>
                     <appendAssemblyId>false</appendAssemblyId>
                     <updateOnly>false</updateOnly>
-                    <descriptor>${project.basedir}/src/assembly/assembly.xml</descriptor>
+                    <descriptors>
+                        <descriptor>${project.basedir}/src/assembly/assembly.xml</descriptor>
+                    </descriptors>
                     <finalName>assembly-wsagent-server-${project.version}</finalName>
                 </configuration>
             </plugin>

--- a/stacks-archetype/src/main/resources/archetype-resources/assembly-che/assembly-main/pom.xml
+++ b/stacks-archetype/src/main/resources/archetype-resources/assembly-che/assembly-main/pom.xml
@@ -43,7 +43,9 @@
                 <configuration>
                     <appendAssemblyId>false</appendAssemblyId>
                     <updateOnly>false</updateOnly>
-                    <descriptor>${project.basedir}/src/assembly/assembly.xml</descriptor>
+                    <descriptors>
+                        <descriptor>${project.basedir}/src/assembly/assembly.xml</descriptor>
+                    </descriptors>
                     <finalName>eclipse-che-${project.version}</finalName>
                     <tarLongFileMode>posix</tarLongFileMode>
                 </configuration>

--- a/stacks-archetype/src/main/resources/archetype-resources/assembly-codenvy/assembly-main/pom.xml
+++ b/stacks-archetype/src/main/resources/archetype-resources/assembly-codenvy/assembly-main/pom.xml
@@ -41,7 +41,9 @@
                 <configuration>
                     <appendAssemblyId>false</appendAssemblyId>
                     <updateOnly>false</updateOnly>
-                    <descriptor>${project.basedir}/src/assembly/assembly.xml</descriptor>
+                    <descriptors>
+                        <descriptor>${project.basedir}/src/assembly/assembly.xml</descriptor>
+                    </descriptors>
                     <finalName>codenvy-onpremises-${project.version}</finalName>
                     <tarLongFileMode>posix</tarLongFileMode>
                 </configuration>


### PR DESCRIPTION
- maven dependency plugin: ignore flag has been renamed
- maven assembly plugin: descriptor is now replaced by descriptors with children descriptor elements

Change-Id: I50c218e2137b306e8903393d7caea28ead611b47
Signed-off-by: Florent BENOIT <fbenoit@redhat.com>