### PR TITLE
IDE.jsp has been moved to _app/ folder under the name IDE.html

### DIFF
--- a/plugin-embedjs-archetype/src/main/resources/archetype-resources/assembly-che/assembly-ide-war/pom.xml
+++ b/plugin-embedjs-archetype/src/main/resources/archetype-resources/assembly-che/assembly-ide-war/pom.xml
@@ -203,11 +203,11 @@
                             <includes>
                                 <include>_app/browserNotSupported.js</include>
                                 <include>_app/favicon.ico</include>
+                                <include>_app/IDE.html</include>
                                 <include>META-INF/context.xml</include>
                                 <include>WEB-INF/rewrite.config</include>
                                 <include>WEB-INF/web.xml</include>
                                 <include>WEB-INF/classes/org/eclipse/che/*.class</include>
-                                <include>IDE.jsp</include>
                             </includes>
                         </overlay>
                         <overlay></overlay>

--- a/plugin-embedjs-archetype/src/main/resources/archetype-resources/assembly-codenvy/assembly-ide-war/pom.xml
+++ b/plugin-embedjs-archetype/src/main/resources/archetype-resources/assembly-codenvy/assembly-ide-war/pom.xml
@@ -208,12 +208,12 @@
                             <includes>
                                 <include>_app/browserNotSupported.js</include>
                                 <include>_app/activity.js</include>
+                                <include>_app/IDE.html</include>
                                 <include>META-INF/context.xml</include>
                                 <include>WEB-INF/rewrite.config</include>
                                 <include>WEB-INF/web.xml</include>
                                 <include>WEB-INF/lib/*.*</include>
                                 <include>WEB-INF/classes/**/*</include>
-                                <include>IDE.jsp</include>
                             </includes>
                         </overlay>
                         <overlay></overlay>

--- a/plugin-json-archetype/src/main/resources/archetype-resources/assembly-che/assembly-ide-war/pom.xml
+++ b/plugin-json-archetype/src/main/resources/archetype-resources/assembly-che/assembly-ide-war/pom.xml
@@ -202,11 +202,11 @@
                             <includes>
                                 <include>_app/browserNotSupported.js</include>
                                 <include>_app/favicon.ico</include>
+                                <include>_app/IDE.html</include>
                                 <include>META-INF/context.xml</include>
                                 <include>WEB-INF/rewrite.config</include>
                                 <include>WEB-INF/web.xml</include>
                                 <include>WEB-INF/classes/org/eclipse/che/*.class</include>
-                                <include>IDE.jsp</include>
                             </includes>
                         </overlay>
                         <overlay></overlay>

--- a/plugin-json-archetype/src/main/resources/archetype-resources/assembly-codenvy/assembly-ide-war/pom.xml
+++ b/plugin-json-archetype/src/main/resources/archetype-resources/assembly-codenvy/assembly-ide-war/pom.xml
@@ -207,12 +207,12 @@
                             <includes>
                                 <include>_app/browserNotSupported.js</include>
                                 <include>_app/activity.js</include>
+                                <include>_app/IDE.html</include>
                                 <include>META-INF/context.xml</include>
                                 <include>WEB-INF/rewrite.config</include>
                                 <include>WEB-INF/web.xml</include>
                                 <include>WEB-INF/lib/*.*</include>
                                 <include>WEB-INF/classes/**/*</include>
-                                <include>IDE.jsp</include>
                             </includes>
                         </overlay>
                         <overlay></overlay>

--- a/plugin-menu-archetype/src/main/resources/archetype-resources/assembly-che/assembly-ide-war/pom.xml
+++ b/plugin-menu-archetype/src/main/resources/archetype-resources/assembly-che/assembly-ide-war/pom.xml
@@ -203,11 +203,11 @@
                             <includes>
                                 <include>_app/browserNotSupported.js</include>
                                 <include>_app/favicon.ico</include>
+                                <include>_app/IDE.html</include>
                                 <include>META-INF/context.xml</include>
                                 <include>WEB-INF/rewrite.config</include>
                                 <include>WEB-INF/web.xml</include>
                                 <include>WEB-INF/classes/org/eclipse/che/*.class</include>
-                                <include>IDE.jsp</include>
                             </includes>
                         </overlay>
                         <overlay></overlay>

--- a/plugin-menu-archetype/src/main/resources/archetype-resources/assembly-codenvy/assembly-ide-war/pom.xml
+++ b/plugin-menu-archetype/src/main/resources/archetype-resources/assembly-codenvy/assembly-ide-war/pom.xml
@@ -208,12 +208,12 @@
                             <includes>
                                 <include>_app/browserNotSupported.js</include>
                                 <include>_app/activity.js</include>
+                                <include>_app/IDE.html</include>
                                 <include>META-INF/context.xml</include>
                                 <include>WEB-INF/rewrite.config</include>
                                 <include>WEB-INF/web.xml</include>
                                 <include>WEB-INF/lib/*.*</include>
                                 <include>WEB-INF/classes/**/*</include>
-                                <include>IDE.jsp</include>
                             </includes>
                         </overlay>
                         <overlay></overlay>

--- a/plugin-serverservice-archetype/src/main/resources/archetype-resources/assembly-che/assembly-ide-war/pom.xml
+++ b/plugin-serverservice-archetype/src/main/resources/archetype-resources/assembly-che/assembly-ide-war/pom.xml
@@ -203,11 +203,11 @@
                             <includes>
                                 <include>_app/browserNotSupported.js</include>
                                 <include>_app/favicon.ico</include>
+                                <include>_app/IDE.html</include>
                                 <include>META-INF/context.xml</include>
                                 <include>WEB-INF/rewrite.config</include>
                                 <include>WEB-INF/web.xml</include>
                                 <include>WEB-INF/classes/org/eclipse/che/*.class</include>
-                                <include>IDE.jsp</include>
                             </includes>
                         </overlay>
                         <overlay></overlay>

--- a/plugin-serverservice-archetype/src/main/resources/archetype-resources/assembly-codenvy/assembly-ide-war/pom.xml
+++ b/plugin-serverservice-archetype/src/main/resources/archetype-resources/assembly-codenvy/assembly-ide-war/pom.xml
@@ -208,12 +208,12 @@
                             <includes>
                                 <include>_app/browserNotSupported.js</include>
                                 <include>_app/activity.js</include>
+                                <include>_app/IDE.html</include>
                                 <include>META-INF/context.xml</include>
                                 <include>WEB-INF/rewrite.config</include>
                                 <include>WEB-INF/web.xml</include>
                                 <include>WEB-INF/lib/*.*</include>
                                 <include>WEB-INF/classes/**/*</include>
-                                <include>IDE.jsp</include>
                             </includes>
                         </overlay>
                         <overlay></overlay>

--- a/plugin-wizard-archetype/src/main/resources/archetype-resources/assembly-che/assembly-ide-war/pom.xml
+++ b/plugin-wizard-archetype/src/main/resources/archetype-resources/assembly-che/assembly-ide-war/pom.xml
@@ -207,11 +207,11 @@
                             <includes>
                                 <include>_app/browserNotSupported.js</include>
                                 <include>_app/favicon.ico</include>
+                                <include>_app/IDE.html</include>
                                 <include>META-INF/context.xml</include>
                                 <include>WEB-INF/rewrite.config</include>
                                 <include>WEB-INF/web.xml</include>
                                 <include>WEB-INF/classes/org/eclipse/che/*.class</include>
-                                <include>IDE.jsp</include>
                             </includes>
                         </overlay>
                         <overlay></overlay>

--- a/plugin-wizard-archetype/src/main/resources/archetype-resources/assembly-codenvy/assembly-ide-war/pom.xml
+++ b/plugin-wizard-archetype/src/main/resources/archetype-resources/assembly-codenvy/assembly-ide-war/pom.xml
@@ -213,12 +213,12 @@
                             <includes>
                                 <include>_app/browserNotSupported.js</include>
                                 <include>_app/activity.js</include>
+                                <include>_app/IDE.html</include>
                                 <include>META-INF/context.xml</include>
                                 <include>WEB-INF/rewrite.config</include>
                                 <include>WEB-INF/web.xml</include>
                                 <include>WEB-INF/lib/*.*</include>
                                 <include>WEB-INF/classes/**/*</include>
-                                <include>IDE.jsp</include>
                             </includes>
                         </overlay>
                         <overlay></overlay>


### PR DESCRIPTION
It fixes https://github.com/eclipse/che/issues/6766

Change-Id: Ibd14b19b7de8ecff798c972f43ea25e6201f8578
Signed-off-by: Florent BENOIT <fbenoit@redhat.com>