### PR TITLE
Use dynamodule plugin for wsmaster and wsagent assemblies

### DIFF
--- a/agent-archetype/src/main/resources/archetype-resources/assembly-che/assembly-wsmaster-war/pom.xml
+++ b/agent-archetype/src/main/resources/archetype-resources/assembly-che/assembly-wsmaster-war/pom.xml
@@ -40,6 +40,21 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.eclipse.che.core</groupId>
+                <artifactId>che-core-dynamodule-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>generate</id>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <scanWarDependencies>true</scanWarDependencies>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>

--- a/agent-archetype/src/main/resources/archetype-resources/assembly-codenvy/assembly-wsmaster-war/pom.xml
+++ b/agent-archetype/src/main/resources/archetype-resources/assembly-codenvy/assembly-wsmaster-war/pom.xml
@@ -38,6 +38,21 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.eclipse.che.core</groupId>
+                <artifactId>che-core-dynamodule-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>generate</id>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <scanWarDependencies>true</scanWarDependencies>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>

--- a/plugin-json-archetype/src/main/resources/archetype-resources/assembly-che/assembly-wsagent-war/pom.xml
+++ b/plugin-json-archetype/src/main/resources/archetype-resources/assembly-che/assembly-wsagent-war/pom.xml
@@ -32,6 +32,21 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.eclipse.che.core</groupId>
+                <artifactId>che-core-dynamodule-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>generate</id>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <scanWarDependencies>true</scanWarDependencies>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>

--- a/plugin-json-archetype/src/main/resources/archetype-resources/assembly-codenvy/assembly-wsagent-war/pom.xml
+++ b/plugin-json-archetype/src/main/resources/archetype-resources/assembly-codenvy/assembly-wsagent-war/pom.xml
@@ -32,6 +32,21 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.eclipse.che.core</groupId>
+                <artifactId>che-core-dynamodule-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>generate</id>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <scanWarDependencies>true</scanWarDependencies>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>

--- a/plugin-serverservice-archetype/src/main/resources/archetype-resources/assembly-che/assembly-wsmaster-war/pom.xml
+++ b/plugin-serverservice-archetype/src/main/resources/archetype-resources/assembly-che/assembly-wsmaster-war/pom.xml
@@ -32,6 +32,21 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.eclipse.che.core</groupId>
+                <artifactId>che-core-dynamodule-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>generate</id>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <scanWarDependencies>true</scanWarDependencies>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>

--- a/plugin-serverservice-archetype/src/main/resources/archetype-resources/assembly-codenvy/assembly-wsmaster-war/pom.xml
+++ b/plugin-serverservice-archetype/src/main/resources/archetype-resources/assembly-codenvy/assembly-wsmaster-war/pom.xml
@@ -32,6 +32,21 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.eclipse.che.core</groupId>
+                <artifactId>che-core-dynamodule-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>generate</id>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <scanWarDependencies>true</scanWarDependencies>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>

--- a/plugin-wizard-archetype/src/main/resources/archetype-resources/assembly-che/assembly-wsagent-war/pom.xml
+++ b/plugin-wizard-archetype/src/main/resources/archetype-resources/assembly-che/assembly-wsagent-war/pom.xml
@@ -32,6 +32,21 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.eclipse.che.core</groupId>
+                <artifactId>che-core-dynamodule-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>generate</id>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <scanWarDependencies>true</scanWarDependencies>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>

--- a/plugin-wizard-archetype/src/main/resources/archetype-resources/assembly-codenvy/assembly-wsagent-war/pom.xml
+++ b/plugin-wizard-archetype/src/main/resources/archetype-resources/assembly-codenvy/assembly-wsagent-war/pom.xml
@@ -32,6 +32,21 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.eclipse.che.core</groupId>
+                <artifactId>che-core-dynamodule-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>generate</id>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <scanWarDependencies>true</scanWarDependencies>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>

--- a/stacks-archetype/src/main/resources/archetype-resources/assembly-che/assembly-wsmaster-war/pom.xml
+++ b/stacks-archetype/src/main/resources/archetype-resources/assembly-che/assembly-wsmaster-war/pom.xml
@@ -34,6 +34,21 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.eclipse.che.core</groupId>
+                <artifactId>che-core-dynamodule-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>generate</id>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <scanWarDependencies>true</scanWarDependencies>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>

--- a/stacks-archetype/src/main/resources/archetype-resources/assembly-codenvy/assembly-wsmaster-war/pom.xml
+++ b/stacks-archetype/src/main/resources/archetype-resources/assembly-codenvy/assembly-wsmaster-war/pom.xml
@@ -32,6 +32,21 @@
     <build>
         <plugins>
             <plugin>
+                    <groupId>org.eclipse.che.core</groupId>
+                    <artifactId>che-core-dynamodule-maven-plugin</artifactId>
+                    <executions>
+                        <execution>
+                            <id>generate</id>
+                            <goals>
+                                <goal>build</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                    <configuration>
+                        <scanWarDependencies>true</scanWarDependencies>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>


### PR DESCRIPTION
### What does this PR do?
Use dynamodule Maven plugin to detect dynamodules in assembly, instead of scanning for them in runtime due to respective changes in Che.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/6283

