### PR TITLE
Remove redundant setting of devModeUrlWhitelistRegexp GWT property

### DIFF
--- a/plugin-embedjs-archetype/src/main/resources/archetype-resources/assembly/assembly-ide-war/src/main/module.gwt.xml
+++ b/plugin-embedjs-archetype/src/main/resources/archetype-resources/assembly/assembly-ide-war/src/main/module.gwt.xml
@@ -14,5 +14,4 @@
 <!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.7.0//EN" "http://gwtproject.org/doctype/2.7.0/gwt-module.dtd">
 <module>
   <entry-point class="org.eclipse.che.ide.client.IDE"/>
-  <set-configuration-property name="devModeUrlWhitelistRegexp" value=".*" />
 </module>

--- a/plugin-json-archetype/src/main/resources/archetype-resources/assembly/assembly-ide-war/src/main/module.gwt.xml
+++ b/plugin-json-archetype/src/main/resources/archetype-resources/assembly/assembly-ide-war/src/main/module.gwt.xml
@@ -14,5 +14,4 @@
 <!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.7.0//EN" "http://gwtproject.org/doctype/2.7.0/gwt-module.dtd">
 <module>
   <entry-point class="org.eclipse.che.ide.client.IDE"/>
-  <set-configuration-property name="devModeUrlWhitelistRegexp" value=".*" />
 </module>

--- a/plugin-menu-archetype/src/main/resources/archetype-resources/assembly/assembly-ide-war/src/main/module.gwt.xml
+++ b/plugin-menu-archetype/src/main/resources/archetype-resources/assembly/assembly-ide-war/src/main/module.gwt.xml
@@ -14,5 +14,4 @@
 <!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.7.0//EN" "http://gwtproject.org/doctype/2.7.0/gwt-module.dtd">
 <module>
   <entry-point class="org.eclipse.che.ide.client.IDE"/>
-  <set-configuration-property name="devModeUrlWhitelistRegexp" value=".*" />
 </module>

--- a/plugin-serverservice-archetype/src/main/resources/archetype-resources/assembly/assembly-ide-war/src/main/module.gwt.xml
+++ b/plugin-serverservice-archetype/src/main/resources/archetype-resources/assembly/assembly-ide-war/src/main/module.gwt.xml
@@ -14,5 +14,4 @@
 <!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.7.0//EN" "http://gwtproject.org/doctype/2.7.0/gwt-module.dtd">
 <module>
   <entry-point class="org.eclipse.che.ide.client.IDE"/>
-  <set-configuration-property name="devModeUrlWhitelistRegexp" value=".*" />
 </module>

--- a/plugin-wizard-archetype/src/main/resources/archetype-resources/assembly/assembly-ide-war/src/main/module.gwt.xml
+++ b/plugin-wizard-archetype/src/main/resources/archetype-resources/assembly/assembly-ide-war/src/main/module.gwt.xml
@@ -14,5 +14,4 @@
 <!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.7.0//EN" "http://gwtproject.org/doctype/2.7.0/gwt-module.dtd">
 <module>
   <entry-point class="org.eclipse.che.ide.client.IDE"/>
-  <set-configuration-property name="devModeUrlWhitelistRegexp" value=".*" />
 </module>


### PR DESCRIPTION
PR removes redundant setting of `devModeUrlWhitelistRegexp` GWT property. Now, it comes from the [Basic IDE](https://github.com/eclipse/che/blob/che6/ide/che-core-ide-app/src/main/module.gwt.xml#L22).

Signed-off-by: Artem Zatsarynnyi <azatsarynnyy@codenvy.com>